### PR TITLE
Create auth middleware and integrate into entity REST endpoints in TS backend

### DIFF
--- a/backend/typescript/middlewares/auth.ts
+++ b/backend/typescript/middlewares/auth.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from "express";
+
+import AuthService from "../services/implementations/authService";
+import IAuthService from "../services/interfaces/authService";
+import { Role } from "../types";
+
+const authService: IAuthService = new AuthService();
+
+const getAccessToken = (req: Request) => {
+  const authHeaderParts = req.headers.authorization?.split(" ");
+  if (
+    authHeaderParts &&
+    authHeaderParts.length >= 2 &&
+    authHeaderParts[0].toLowerCase() === "bearer"
+  ) {
+    return authHeaderParts[1];
+  }
+  return null;
+};
+
+const isAuthorized = (roles: Set<Role>) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const accessToken = getAccessToken(req);
+    const authorized =
+      accessToken && (await authService.isAuthorized(accessToken, roles));
+    if (!authorized) {
+      return res
+        .status(401)
+        .json({ error: "You are not authorized to make this request." });
+    }
+    return next();
+  };
+};
+
+export default isAuthorized;

--- a/backend/typescript/middlewares/auth.ts
+++ b/backend/typescript/middlewares/auth.ts
@@ -18,11 +18,12 @@ const getAccessToken = (req: Request) => {
   return null;
 };
 
-const isAuthorized = (roles: Set<Role>) => {
+/* Determine if request is authorized based on accessToken validity and role of client */
+export const isAuthorizedByRole = (roles: Set<Role>) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const accessToken = getAccessToken(req);
     const authorized =
-      accessToken && (await authService.isAuthorized(accessToken, roles));
+      accessToken && (await authService.isAuthorizedByRole(accessToken, roles));
     if (!authorized) {
       return res
         .status(401)
@@ -32,4 +33,44 @@ const isAuthorized = (roles: Set<Role>) => {
   };
 };
 
-export default isAuthorized;
+/* Determine if request for a user-specific resource is authorized based on accessToken
+ * validity and if the userId that the token was issued to matches the requested userId
+ * Note: userIdField is the name of the request parameter containing the requested userId */
+export const isAuthorizedByUserId = (userIdField: string) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const accessToken = getAccessToken(req);
+    const authorized =
+      accessToken &&
+      (await authService.isAuthorizedByUserId(
+        accessToken,
+        req.params[userIdField],
+      ));
+    if (!authorized) {
+      return res
+        .status(401)
+        .json({ error: "You are not authorized to make this request." });
+    }
+    return next();
+  };
+};
+
+/* Determine if request for a user-specific resource is authorized based on accessToken
+ * validity and if the email that the token was issued to matches the requested email
+ * Note: emailField is the name of the request parameter containing the requested email */
+export const isAuthorizedByEmail = (emailField: string) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const accessToken = getAccessToken(req);
+    const authorized =
+      accessToken &&
+      (await authService.isAuthorizedByEmail(
+        accessToken,
+        req.params[emailField],
+      ));
+    if (!authorized) {
+      return res
+        .status(401)
+        .json({ error: "You are not authorized to make this request." });
+    }
+    return next();
+  };
+};

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 
+import { isAuthorizedByEmail, isAuthorizedByUserId } from "../middlewares/auth";
 import AuthService from "../services/implementations/authService";
 import IAuthService from "../services/interfaces/authService";
 
@@ -46,26 +47,34 @@ authRouter.post("/refresh", async (req, res) => {
 });
 
 /* Revokes all of the specified user's refresh tokens */
-authRouter.post("/logout/:userId", async (req, res) => {
-  try {
-    await authService.revokeTokens(req.params.userId);
-    res.status(204).send();
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
+authRouter.post(
+  "/logout/:userId",
+  isAuthorizedByUserId("userId"),
+  async (req, res) => {
+    try {
+      await authService.revokeTokens(req.params.userId);
+      res.status(204).send();
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  },
+);
 
 /* Returns a password reset link for the user with the specified email */
 /* TODO: actually send reset link in an email */
-authRouter.post("/resetPassword/:email", async (req, res) => {
-  try {
-    const resetLink = await authService.generatePasswordResetLink(
-      req.params.email,
-    );
-    res.status(200).json({ resetLink });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
+authRouter.post(
+  "/resetPassword/:email",
+  isAuthorizedByEmail("email"),
+  async (req, res) => {
+    try {
+      const resetLink = await authService.generatePasswordResetLink(
+        req.params.email,
+      );
+      res.status(200).json({ resetLink });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  },
+);
 
 export default authRouter;

--- a/backend/typescript/rest/entityRoutes.ts
+++ b/backend/typescript/rest/entityRoutes.ts
@@ -1,13 +1,18 @@
 import { Router } from "express";
+
+import isAuthorized from "../middlewares/auth";
 import EntityService from "../services/implementations/EntityService";
+import { IEntityService } from "../services/interfaces/IEntityService";
 
 const entityRouter: Router = Router();
-const entService = new EntityService();
+entityRouter.use(isAuthorized(new Set(["User", "Admin"])));
 
-/* Create entity Object */
+const entityService: IEntityService = new EntityService();
+
+/* Create entity */
 entityRouter.post("/", async (req, res) => {
   try {
-    const newEntity = await entService.createEntity({
+    const newEntity = await entityService.createEntity({
       stringField: req.body.stringField,
       intField: req.body.intField,
       enumField: req.body.enumField,
@@ -20,33 +25,33 @@ entityRouter.post("/", async (req, res) => {
   }
 });
 
-/* Get all entity objects */
-entityRouter.get("/", async (req, res) => {
+/* Get all entities */
+entityRouter.get("/", async (_req, res) => {
   try {
-    const entities = await entService.getEntities();
+    const entities = await entityService.getEntities();
     res.status(200).json(entities);
   } catch (e) {
     res.status(500).send(e.message);
   }
 });
 
-/* Get entity object by id */
+/* Get entity by id */
 entityRouter.get("/:id", async (req, res) => {
   const { id } = req.params;
 
   try {
-    const entity = await entService.getEntity(id);
+    const entity = await entityService.getEntity(id);
     res.status(200).json(entity);
   } catch (e) {
     res.status(500).send(e.message);
   }
 });
 
-/* Update entity object by id */
+/* Update entity by id */
 entityRouter.put("/:id", async (req, res) => {
   const { id } = req.params;
   try {
-    const entity = await entService.updateEntity(id, {
+    const entity = await entityService.updateEntity(id, {
       stringField: req.body.stringField,
       intField: req.body.intField,
       enumField: req.body.enumField,
@@ -59,12 +64,12 @@ entityRouter.put("/:id", async (req, res) => {
   }
 });
 
-/* Delete entity object by id */
+/* Delete entity by id */
 entityRouter.delete("/:id", async (req, res) => {
   const { id } = req.params;
 
   try {
-    await entService.deleteEntity(id);
+    await entityService.deleteEntity(id);
     res.status(204).send();
   } catch (e) {
     res.status(500).send(e.message);

--- a/backend/typescript/rest/entityRoutes.ts
+++ b/backend/typescript/rest/entityRoutes.ts
@@ -1,11 +1,11 @@
 import { Router } from "express";
 
-import isAuthorized from "../middlewares/auth";
+import { isAuthorizedByRole } from "../middlewares/auth";
 import EntityService from "../services/implementations/EntityService";
 import { IEntityService } from "../services/interfaces/IEntityService";
 
 const entityRouter: Router = Router();
-entityRouter.use(isAuthorized(new Set(["User", "Admin"])));
+entityRouter.use(isAuthorizedByRole(new Set(["User", "Admin"])));
 
 const entityService: IEntityService = new EntityService();
 

--- a/backend/typescript/rest/userRoutes.ts
+++ b/backend/typescript/rest/userRoutes.ts
@@ -1,9 +1,12 @@
 import { Router } from "express";
 
+import { isAuthorizedByRole } from "../middlewares/auth";
 import UserService from "../services/implementations/userService";
 import IUserService from "../services/interfaces/userService";
 
 const userRouter: Router = Router();
+userRouter.use(isAuthorizedByRole(new Set(["Admin"])));
+
 const userService: IUserService = new UserService();
 
 /* Get all users, optionally filter by a userId or email query parameter to retrieve a single user */

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -62,7 +62,10 @@ class AuthService implements IAuthService {
     }
   }
 
-  async isAuthorized(accessToken: string, roles: Set<Role>): Promise<boolean> {
+  async isAuthorizedByRole(
+    accessToken: string,
+    roles: Set<Role>,
+  ): Promise<boolean> {
     try {
       const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
         .auth()
@@ -72,6 +75,38 @@ class AuthService implements IAuthService {
       );
 
       return roles.has(userRole);
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async isAuthorizedByUserId(
+    accessToken: string,
+    requestedUserId: string,
+  ): Promise<boolean> {
+    try {
+      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
+        .auth()
+        .verifyIdToken(accessToken, true);
+      const tokenUserId = await this.userService.getUserIdByAuthId(
+        decodedIdToken.uid,
+      );
+
+      return tokenUserId === requestedUserId;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async isAuthorizedByEmail(
+    accessToken: string,
+    requestedEmail: string,
+  ): Promise<boolean> {
+    try {
+      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
+        .auth()
+        .verifyIdToken(accessToken, true);
+      return decodedIdToken.email === requestedEmail;
     } catch (error) {
       return false;
     }

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -62,7 +62,7 @@ class AuthService implements IAuthService {
     }
   }
 
-  async isAuthorized(accessToken: string, role: Role): Promise<boolean> {
+  async isAuthorized(accessToken: string, roles: Set<Role>): Promise<boolean> {
     try {
       const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
         .auth()
@@ -71,7 +71,7 @@ class AuthService implements IAuthService {
         decodedIdToken.uid,
       );
 
-      return userRole === role;
+      return roles.has(userRole);
     } catch (error) {
       return false;
     }

--- a/backend/typescript/services/implementations/userService.ts
+++ b/backend/typescript/services/implementations/userService.ts
@@ -5,6 +5,14 @@ import MgUser, { User } from "../../models/user.mgmodel";
 import { CreateUserDTO, Role, UpdateUserDTO, UserDTO } from "../../types";
 import Logger from "../../utilities/logger";
 
+const getMongoUserByAuthId = async (authId: string): Promise<User> => {
+  const user: User | null = await MgUser.findOne({ authId });
+  if (!user) {
+    throw new Error(`user with authId ${authId} not found.`);
+  }
+  return user;
+};
+
 class UserService implements IUserService {
   /* eslint-disable class-methods-use-this */
   async getUserById(userId: string): Promise<UserDTO> {
@@ -60,13 +68,20 @@ class UserService implements IUserService {
 
   async getUserRoleByAuthId(authId: string): Promise<Role> {
     try {
-      const user: User | null = await MgUser.findOne({ authId });
-      if (!user) {
-        throw new Error(`userId with authId ${authId} not found.`);
-      }
-      return user.role;
+      const { role } = await getMongoUserByAuthId(authId);
+      return role;
     } catch (error) {
       Logger.error(`Failed to get user role. Reason = ${error.message}`);
+      throw error;
+    }
+  }
+
+  async getUserIdByAuthId(authId: string): Promise<string> {
+    try {
+      const { id } = await getMongoUserByAuthId(authId);
+      return id;
+    } catch (error) {
+      Logger.error(`Failed to get user id. Reason = ${error.message}`);
       throw error;
     }
   }

--- a/backend/typescript/services/interfaces/authService.ts
+++ b/backend/typescript/services/interfaces/authService.ts
@@ -44,7 +44,30 @@ interface IAuthService {
    * @param roles roles to check for
    * @returns true if token valid and authorized, false otherwise
    */
-  isAuthorized(accessToken: string, roles: Set<Role>): Promise<boolean>;
+  isAuthorizedByRole(accessToken: string, roles: Set<Role>): Promise<boolean>;
+
+  /**
+   * Determine if the provided access token is valid and issued to the requested user
+   * @param accessToken user's access token
+   * @param requestedUserId userId of requested user
+   * @returns true if token valid and authorized, false otherwise
+   */
+  isAuthorizedByUserId(
+    accessToken: string,
+    requestedUserId: string,
+  ): Promise<boolean>;
+
+  /**
+   * Determine if the provided access token is valid and issued to the requested user
+   * with the specified email address
+   * @param accessToken user's access token
+   * @param requestedEmail email address of requested user
+   * @returns true if token valid and authorized, false otherwise
+   */
+  isAuthorizedByEmail(
+    accessToken: string,
+    requestedEmail: string,
+  ): Promise<boolean>;
 }
 
 export default IAuthService;

--- a/backend/typescript/services/interfaces/authService.ts
+++ b/backend/typescript/services/interfaces/authService.ts
@@ -38,13 +38,13 @@ interface IAuthService {
   // (dependent on EmailService)
 
   /**
-   * Determine if the provided access token is valid and authorized for the
-   * specified role
+   * Determine if the provided access token is valid and authorized for at least
+   * one of the specified roles
    * @param accessToken user's access token
-   * @param role role to check for
+   * @param roles roles to check for
    * @returns true if token valid and authorized, false otherwise
    */
-  isAuthorized(accessToken: string, role: Role): Promise<boolean>;
+  isAuthorized(accessToken: string, roles: Set<Role>): Promise<boolean>;
 }
 
 export default IAuthService;

--- a/backend/typescript/services/interfaces/userService.ts
+++ b/backend/typescript/services/interfaces/userService.ts
@@ -26,6 +26,14 @@ interface IUserService {
   getUserRoleByAuthId(authId: string): Promise<Role>;
 
   /**
+   * Get id of user associated with authId
+   * @param authId user's authId
+   * @returns id of the user
+   * @throws Error if user id retrieval fails
+   */
+  getUserIdByAuthId(authId: string): Promise<string>;
+
+  /**
    * Get authId of user associated with id
    * @param userId user's id
    * @returns user's authId


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[User authentication middleware for REST endpoints](https://www.notion.so/uwblueprintexecs/User-authentication-middleware-for-REST-endpoints-11bc263c2c6a4030a8a9870d08de13aa)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Created Express.js middleware to check authorization (passed through request headers)
    * Authorization can be based on role, or based on matching the userId or email associated with the requested resource with the userId or email associated with the access token (e.g. a user is only permitted to log themselves out, not anyone else)
* Added these middlewares to REST endpoints
    * Any authenticated user can make requests to `/entities`
    * Any user with "Admin" role can make requests to `/users` (current imagined use case is an admin user management page)
    * Any user can make a request to `/auth/login` and `/auth/refresh`
    * Only an authenticated user with the userId in the URL can make a request to `/auth/logout/:userId`
    * Only an authenticated user with the email in the URL can make a request to `/auth/resetPassword/:email`
* Created new `AuthService` methods that are used by the middlewares, modified `AuthService.isAuthorizedByRole` to check a set of roles (we don't have a concept of hierarchy right now so all authorized roles must be explicitly specified)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Generate an access token: POST `/auth/login` with a body in this format:
```
{
    "email": "first.last@domain.org",
    "password": "password"
}
```
2. Send requests to entity REST endpoints with `Authorization: bearer <insert-access-token>` header, you should get a normal response
3. Send requests without the auth header, you should get a 401 error
4. Change your role to "Admin" if it isn't already (modify directly in MongoDB Atlas), then send requests to `/users` endpoints with `Authorization: bearer <insert-access-token>` header
5. Send POST request to `/auth/resetPassword/<not-your-email>` and the authorization header, you should get a 401 error. Now switch to your own email and a reset link should be returned.
6. Send POST request to `/auth/logout/<not-your-userId>` and the authorization header, you should get a 401 error. Now switch to your own userId and logout should succeed



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* backend/typescript/middlewares/auth.ts
* backend/typescript/services/implementations/authService.ts


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
