### PR TITLE
Decouple TypeScript AuthService from UserService

### DIFF
--- a/backend/typescript/graphql/resolvers/authResolvers.ts
+++ b/backend/typescript/graphql/resolvers/authResolvers.ts
@@ -1,9 +1,10 @@
 import { CookieOptions, Request, Response } from "express";
 
 import AuthService from "../../services/implementations/authService";
+import UserService from "../../services/implementations/userService";
 import IAuthService from "../../services/interfaces/authService";
 
-const authService: IAuthService = new AuthService();
+const authService: IAuthService = new AuthService(new UserService());
 
 const cookieOptions: CookieOptions = {
   httpOnly: true,

--- a/backend/typescript/middlewares/auth.graphql.ts
+++ b/backend/typescript/middlewares/auth.graphql.ts
@@ -3,10 +3,11 @@ import { GraphQLResolveInfo } from "graphql";
 
 import { getAccessToken } from "./auth";
 import AuthService from "../services/implementations/authService";
+import UserService from "../services/implementations/userService";
 import IAuthService from "../services/interfaces/authService";
 import { Role } from "../types";
 
-const authService: IAuthService = new AuthService();
+const authService: IAuthService = new AuthService(new UserService());
 
 /* Determine if request is authorized based on accessToken validity and role of client */
 export const isAuthorizedByRole = (roles: Set<Role>) => {

--- a/backend/typescript/middlewares/auth.ts
+++ b/backend/typescript/middlewares/auth.ts
@@ -1,10 +1,11 @@
 import { NextFunction, Request, Response } from "express";
 
 import AuthService from "../services/implementations/authService";
+import UserService from "../services/implementations/userService";
 import IAuthService from "../services/interfaces/authService";
 import { Role } from "../types";
 
-const authService: IAuthService = new AuthService();
+const authService: IAuthService = new AuthService(new UserService());
 
 export const getAccessToken = (req: Request) => {
   const authHeaderParts = req.headers.authorization?.split(" ");

--- a/backend/typescript/rest/authRoutes.ts
+++ b/backend/typescript/rest/authRoutes.ts
@@ -2,10 +2,11 @@ import { Router } from "express";
 
 import { isAuthorizedByEmail, isAuthorizedByUserId } from "../middlewares/auth";
 import AuthService from "../services/implementations/authService";
+import UserService from "../services/implementations/userService";
 import IAuthService from "../services/interfaces/authService";
 
 const authRouter: Router = Router();
-const authService: IAuthService = new AuthService();
+const authService: IAuthService = new AuthService(new UserService());
 
 /* Returns access token in response body and sets refreshToken as an httpOnly cookie */
 authRouter.post("/login", async (req, res) => {

--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -1,6 +1,5 @@
 import * as firebaseAdmin from "firebase-admin";
 
-import UserService from "./userService";
 import IAuthService from "../interfaces/authService";
 import IUserService from "../interfaces/userService";
 import { Token, Role } from "../../types";
@@ -10,8 +9,8 @@ import Logger from "../../utilities/logger";
 class AuthService implements IAuthService {
   userService: IUserService;
 
-  constructor() {
-    this.userService = new UserService();
+  constructor(userService: IUserService) {
+    this.userService = userService;
   }
 
   /* eslint-disable class-methods-use-this */


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Decouple AuthService and UserService](https://www.notion.so/uwblueprintexecs/Decouple-AuthService-and-UserService-d5342193b6544bb597c63fc9527ef2c2)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Made UserService a constructor argument to AuthService so we can easily switch between the MongoDB and PostgreSQL implementations of UserService


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Try any REST or GraphQL endpoint that makes use of UserService and AuthService (e.g. any endpoint requiring authorization like `/users`, or `/entities`)


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Did I miss any AuthService constructor calls that need to be updated?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
