### PR TITLE
Fix user id type issue when using PostgreSQL

### DIFF
--- a/backend/typescript/services/implementations/authService.ts
+++ b/backend/typescript/services/implementations/authService.ts
@@ -122,7 +122,7 @@ class AuthService implements IAuthService {
         decodedIdToken.uid,
       );
 
-      return tokenUserId === requestedUserId;
+      return String(tokenUserId) === requestedUserId;
     } catch (error) {
       return false;
     }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
N/A - quick fix


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Cast user id to be a string when checking authorization by user id (the Sequelize module is not too well typed, the id is an `any` so this was unfortunately not caught by typechecking)


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Login and then logout using the TS + Postgres backend (you'll need to seed an admin user into your local DB if you don't have one)
```sql
insert into users (first_name, last_name, auth_id, role, "createdAt", "updatedAt") values ('First', 'Last', 'insert-firebase-uid', 'Admin', '2021-04-30', '2021-04-30');
```


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
