### PR TITLE
Refactor auth functions that use localStorage logic into AuthAPIClient

### DIFF
--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -1,3 +1,6 @@
+// graphql {
+// import { gql, useMutation } from "@apollo/client";
+// } graphql
 import baseAPIClient from "./BaseAPIClient";
 import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
 import { AuthenticatedUser } from "../contexts/AuthContext";
@@ -5,6 +8,22 @@ import {
   getLocalStorageObjProperty,
   setLocalStorageObjProperty,
 } from "../utils/LocalStorageUtils";
+
+// const login = async (
+//   email: string,
+//   password: string,
+//   loginFunction: Function,
+// ) => {
+//   const result = await loginFunction({ variables: { email, password } });
+//   let user: AuthenticatedUser = null;
+//   if (result) {
+//     user = result.data?.login ?? null;
+//     if (user) {
+//       localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(user));
+//     }
+//   }
+//   return user;
+// };
 
 const login = async (
   email: string,
@@ -78,3 +97,4 @@ const refresh = async (): Promise<boolean> => {
 };
 
 export default { login, logout, resetPassword, refresh };
+// export default { login };

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -1,100 +1,134 @@
-// graphql {
-// import { gql, useMutation } from "@apollo/client";
-// } graphql
-import baseAPIClient from "./BaseAPIClient";
 import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
 import { AuthenticatedUser } from "../contexts/AuthContext";
-import {
-  getLocalStorageObjProperty,
-  setLocalStorageObjProperty,
-} from "../utils/LocalStorageUtils";
+// rest {
+// import baseAPIClient from "./BaseAPIClient";
+// import {
+//   getLocalStorageObjProperty,
+//   setLocalStorageObjProperty,
+// } from "../utils/LocalStorageUtils";
+// } rest
+// graphql {
+import { setLocalStorageObjProperty } from "../utils/LocalStorageUtils";
+// } graphql
 
-// const login = async (
-//   email: string,
-//   password: string,
-//   loginFunction: Function,
-// ) => {
-//   const result = await loginFunction({ variables: { email, password } });
-//   let user: AuthenticatedUser = null;
-//   if (result) {
-//     user = result.data?.login ?? null;
-//     if (user) {
-//       localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(user));
-//     }
-//   }
-//   return user;
-// };
-
+// graphql {
 const login = async (
   email: string,
   password: string,
-): Promise<AuthenticatedUser> => {
-  try {
-    const { data } = await baseAPIClient.post(
-      "/auth/login",
-      { email, password },
-      { withCredentials: true },
-    );
-    localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(data));
-    return data;
-  } catch (error) {
-    return null;
+  loginFunction: Function,
+) => {
+  const result = await loginFunction({ variables: { email, password } });
+  let user: AuthenticatedUser = null;
+  if (result) {
+    user = result.data?.login ?? null;
+    if (user) {
+      localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(user));
+    }
   }
+  return user;
 };
 
-const logout = async (userId: string | undefined): Promise<boolean> => {
-  const bearerToken = `Bearer ${getLocalStorageObjProperty(
-    AUTHENTICATED_USER_KEY,
-    "accessToken",
-  )}`;
-  try {
-    await baseAPIClient.post(
-      `/auth/logout/${userId}`,
-      {},
-      { headers: { Authorization: bearerToken } },
-    );
+const logout = async (
+  authenticatedUserId: string,
+  logoutFunction: Function,
+) => {
+  const result = await logoutFunction({
+    variables: { userId: authenticatedUserId },
+  });
+  let success: boolean = false;
+  if (result.data?.logout === null) {
+    success = true;
     localStorage.removeItem(AUTHENTICATED_USER_KEY);
-    return true;
-  } catch (error) {
-    return false;
   }
+  return success;
 };
 
-const resetPassword = async (email: string | undefined): Promise<boolean> => {
-  const bearerToken = `Bearer ${getLocalStorageObjProperty(
-    AUTHENTICATED_USER_KEY,
-    "accessToken",
-  )}`;
-  try {
-    await baseAPIClient.post(
-      `/auth/resetPassword/${email}`,
-      {},
-      { headers: { Authorization: bearerToken } },
-    );
-    return true;
-  } catch (error) {
-    return false;
+const refresh = async (refreshFunction: Function) => {
+  const result = await refreshFunction();
+  let success: boolean = false;
+  const token = result.data?.refresh;
+  if (token) {
+    success = true;
+    setLocalStorageObjProperty(AUTHENTICATED_USER_KEY, "accessToken", token);
   }
+  return success;
 };
+
+export default { login, logout, refresh };
+
+// } graphql
+
+// rest {
+// const login = async (
+//   email: string,
+//   password: string,
+// ): Promise<AuthenticatedUser> => {
+//   try {
+//     const { data } = await baseAPIClient.post(
+//       "/auth/login",
+//       { email, password },
+//       { withCredentials: true },
+//     );
+//     localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(data));
+//     return data;
+//   } catch (error) {
+//     return null;
+//   }
+// };
+
+// const logout = async (userId: string | undefined): Promise<boolean> => {
+//   const bearerToken = `Bearer ${getLocalStorageObjProperty(
+//     AUTHENTICATED_USER_KEY,
+//     "accessToken",
+//   )}`;
+//   try {
+//     await baseAPIClient.post(
+//       `/auth/logout/${userId}`,
+//       {},
+//       { headers: { Authorization: bearerToken } },
+//     );
+//     localStorage.removeItem(AUTHENTICATED_USER_KEY);
+//     return true;
+//   } catch (error) {
+//     return false;
+//   }
+// };
+
+// const resetPassword = async (email: string | undefined): Promise<boolean> => {
+//   const bearerToken = `Bearer ${getLocalStorageObjProperty(
+//     AUTHENTICATED_USER_KEY,
+//     "accessToken",
+//   )}`;
+//   try {
+//     await baseAPIClient.post(
+//       `/auth/resetPassword/${email}`,
+//       {},
+//       { headers: { Authorization: bearerToken } },
+//     );
+//     return true;
+//   } catch (error) {
+//     return false;
+//   }
+// };
 
 // for testing only, refresh does not need to be exposed in the client
-const refresh = async (): Promise<boolean> => {
-  try {
-    const { data } = await baseAPIClient.post(
-      "/auth/refresh",
-      {},
-      { withCredentials: true },
-    );
-    setLocalStorageObjProperty(
-      AUTHENTICATED_USER_KEY,
-      "accessToken",
-      data.accessToken,
-    );
-    return true;
-  } catch (error) {
-    return false;
-  }
-};
+// const refresh = async (): Promise<boolean> => {
+//   try {
+//     const { data } = await baseAPIClient.post(
+//       "/auth/refresh",
+//       {},
+//       { withCredentials: true },
+//     );
+//     setLocalStorageObjProperty(
+//       AUTHENTICATED_USER_KEY,
+//       "accessToken",
+//       data.accessToken,
+//     );
+//     return true;
+//   } catch (error) {
+//     return false;
+//   }
+// };
 
-export default { login, logout, resetPassword, refresh };
-// export default { login };
+// export default { login, logout, resetPassword, refresh };
+// } rest

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -1,3 +1,8 @@
+import {
+  FetchResult,
+  MutationFunctionOptions,
+  OperationVariables,
+} from "@apollo/client";
 import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
 import { AuthenticatedUser } from "../contexts/AuthContext";
 // rest {
@@ -15,7 +20,20 @@ import { setLocalStorageObjProperty } from "../utils/LocalStorageUtils";
 const login = async (
   email: string,
   password: string,
-  loginFunction: Function,
+  loginFunction: (
+    options?:
+      | MutationFunctionOptions<
+          { login: AuthenticatedUser },
+          OperationVariables
+        >
+      | undefined,
+  ) => Promise<
+    FetchResult<
+      { login: AuthenticatedUser },
+      Record<string, any>,
+      Record<string, any>
+    >
+  >,
 ) => {
   const result = await loginFunction({ variables: { email, password } });
   let user: AuthenticatedUser = null;
@@ -30,7 +48,24 @@ const login = async (
 
 const logout = async (
   authenticatedUserId: string,
-  logoutFunction: Function,
+  logoutFunction: (
+    options?:
+      | MutationFunctionOptions<
+          {
+            logout: null;
+          },
+          OperationVariables
+        >
+      | undefined,
+  ) => Promise<
+    FetchResult<
+      {
+        logout: null;
+      },
+      Record<string, any>,
+      Record<string, any>
+    >
+  >,
 ) => {
   const result = await logoutFunction({
     variables: { userId: authenticatedUserId },
@@ -43,7 +78,26 @@ const logout = async (
   return success;
 };
 
-const refresh = async (refreshFunction: Function) => {
+const refresh = async (
+  refreshFunction: (
+    options?:
+      | MutationFunctionOptions<
+          {
+            refresh: string;
+          },
+          OperationVariables
+        >
+      | undefined,
+  ) => Promise<
+    FetchResult<
+      {
+        refresh: string;
+      },
+      Record<string, any>,
+      Record<string, any>
+    >
+  >,
+) => {
   const result = await refreshFunction();
   let success: boolean = false;
   const token = result.data?.refresh;

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -4,12 +4,7 @@ import { Redirect } from "react-router-dom";
 import { gql, useMutation } from "@apollo/client";
 // } graphql
 
-// rest {
-// import authAPIClient from "../../APIClients/AuthAPIClient";
-// } rest
-// graphql {
-import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
-// } graphql
+import authAPIClient from "../../APIClients/AuthAPIClient";
 import AuthContext, { AuthenticatedUser } from "../../contexts/AuthContext";
 
 // graphql {
@@ -38,19 +33,11 @@ const Login = () => {
 
   const onLogInClick = async () => {
     // graphql {
-    const result = await login({ variables: { email, password } });
-    let user: AuthenticatedUser = null;
-    if (result) {
-      user = result.data?.login ?? null;
-      if (user) {
-        localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(user));
-      }
-    }
-    // const user: AuthenticatedUser = await authAPIClient.login(
-    //   email,
-    //   password,
-    //   login,
-    // );
+    const user: AuthenticatedUser = await authAPIClient.login(
+      email,
+      password,
+      login,
+    );
     // } graphql
     // rest {
     // const user: AuthenticatedUser = await authAPIClient.login(email, password);

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -46,6 +46,11 @@ const Login = () => {
         localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(user));
       }
     }
+    // const user: AuthenticatedUser = await authAPIClient.login(
+    //   email,
+    //   password,
+    //   login,
+    // );
     // } graphql
     // rest {
     // const user: AuthenticatedUser = await authAPIClient.login(email, password);

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -4,12 +4,10 @@ import { gql, useMutation } from "@apollo/client";
 // } graphql
 
 // rest {
-// import authAPIClient from "../../APIClients/AuthAPIClient";
+import authAPIClient from "../../APIClients/AuthAPIClient";
 // } rest
 import AuthContext from "../../contexts/AuthContext";
 // graphql {
-import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
-
 const LOGOUT = gql`
   mutation Logout($userId: ID!) {
     logout(userId: $userId)
@@ -26,14 +24,10 @@ const Logout = () => {
 
   const onLogOutClick = async () => {
     // graphql {
-    const result = await logout({
-      variables: { userId: String(authenticatedUser?.id) },
-    });
-    let success: boolean = false;
-    if (result.data?.logout === null) {
-      success = true;
-      localStorage.removeItem(AUTHENTICATED_USER_KEY);
-    }
+    const success = await authAPIClient.logout(
+      String(authenticatedUser?.id),
+      logout,
+    );
     // } graphql
     // rest {
     // const success = await authAPIClient.logout(authenticatedUser?.id);

--- a/frontend/src/components/auth/Logout.tsx
+++ b/frontend/src/components/auth/Logout.tsx
@@ -3,9 +3,7 @@ import React, { useContext } from "react";
 import { gql, useMutation } from "@apollo/client";
 // } graphql
 
-// rest {
 import authAPIClient from "../../APIClients/AuthAPIClient";
-// } rest
 import AuthContext from "../../contexts/AuthContext";
 // graphql {
 const LOGOUT = gql`

--- a/frontend/src/components/auth/RefreshCredentials.tsx
+++ b/frontend/src/components/auth/RefreshCredentials.tsx
@@ -3,14 +3,10 @@ import React, { useContext } from "react";
 import { gql, useMutation } from "@apollo/client";
 // } graphql
 
-// rest {
-// import authAPIClient from "../../APIClients/AuthAPIClient";
-// } rest
+import authAPIClient from "../../APIClients/AuthAPIClient";
 import AuthContext from "../../contexts/AuthContext";
-// graphql {
-import AUTHENTICATED_USER_KEY from "../../constants/AuthConstants";
-import { setLocalStorageObjProperty } from "../../utils/LocalStorageUtils";
 
+// graphql {
 const REFRESH = gql`
   mutation Refresh {
     refresh
@@ -27,13 +23,7 @@ const RefreshCredentials = () => {
 
   const onRefreshClick = async () => {
     // graphql {
-    const result = await refresh();
-    let success: boolean = false;
-    const token = result.data?.refresh;
-    if (token) {
-      success = true;
-      setLocalStorageObjProperty(AUTHENTICATED_USER_KEY, "accessToken", token);
-    }
+    const success = await authAPIClient.refresh(refresh);
     // } graphql
     // rest {
     // const success = await authAPIClient.refresh();


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Refactor token storage logic out of auth components in GraphQL frontend client](https://www.notion.so/uwblueprintexecs/Refactor-token-storage-logic-out-of-auth-components-in-GraphQL-frontend-client-7d8bed2ef34e415592fe24fb76673d39)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Removed `localStorage` functionality from UI components and moved it to `AuthAPIClient` by passing necessary parameters to these new helper functions
* Added GraphQL tags to the required functions in `AuthAPIClient` to replace functions if REST is chosen instead


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the app
2. Log in successfully
3. Refresh credentials successfully
4. Logout successfully


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* the added functions in `AuthAPIClient`
* the scrubber tags to ensure the correct areas are tagged


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
