### PR TITLE
Add swagger for typescript backend

### DIFF
--- a/backend/typescript/package.json
+++ b/backend/typescript/package.json
@@ -13,6 +13,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/swagger-ui-express": "^4.1.2",
+    "@types/yamljs": "^0.2.31",
     "apollo-server": "^2.22.2",
     "apollo-server-express": "^2.22.2",
     "cookie-parser": "^1.4.5",
@@ -30,9 +32,11 @@
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.5.0",
     "sequelize-typescript": "^2.1.0",
+    "swagger-ui-express": "^4.1.6",
     "ts-node": "^10.0.0",
     "umzug": "^3.0.0-beta.16",
-    "winston": "^3.3.3"
+    "winston": "^3.3.3",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.2",

--- a/backend/typescript/server.ts
+++ b/backend/typescript/server.ts
@@ -2,8 +2,8 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
 import * as firebaseAdmin from "firebase-admin";
-import swaggerUi from 'swagger-ui-express';
-import YAML from 'yamljs';
+import swaggerUi from "swagger-ui-express";
+import YAML from "yamljs";
 
 import { ApolloServer } from "apollo-server-express";
 import { mongo, sequelize } from "./models";
@@ -20,7 +20,7 @@ const CORS_OPTIONS: cors.CorsOptions = {
   credentials: true,
 };
 
-const swaggerDocument = YAML.load('swagger.yml');
+const swaggerDocument = YAML.load("swagger.yml");
 
 const app = express();
 app.use(cookieParser());
@@ -31,7 +31,7 @@ app.use(express.urlencoded());
 app.use("/auth", authRouter);
 app.use("/entities", entityRouter);
 app.use("/users", userRouter);
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 const server = new ApolloServer({
   schema,

--- a/backend/typescript/server.ts
+++ b/backend/typescript/server.ts
@@ -2,6 +2,8 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import express from "express";
 import * as firebaseAdmin from "firebase-admin";
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yamljs';
 
 import { ApolloServer } from "apollo-server-express";
 import { mongo, sequelize } from "./models";
@@ -18,6 +20,8 @@ const CORS_OPTIONS: cors.CorsOptions = {
   credentials: true,
 };
 
+const swaggerDocument = YAML.load('swagger.yml');
+
 const app = express();
 app.use(cookieParser());
 app.use(cors(CORS_OPTIONS));
@@ -27,6 +31,7 @@ app.use(express.urlencoded());
 app.use("/auth", authRouter);
 app.use("/entities", entityRouter);
 app.use("/users", userRouter);
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 const server = new ApolloServer({
   schema,

--- a/backend/typescript/swagger.yml
+++ b/backend/typescript/swagger.yml
@@ -39,7 +39,9 @@ paths:
                     stringField:
                       type: string
                     stringArrayField:
-                      type: string
+                      type: array
+                      items:
+                        type: string
                     enumField:
                       type: string
                       enum: ["A", "B", "C", "D"]
@@ -71,7 +73,9 @@ paths:
                 stringField:
                   type: string
                 stringArrayField:
-                  type: string
+                  type: array
+                  items:
+                    type: string
                 enumField:
                   type: string
                   enum: ["A", "B", "C", "D"]
@@ -92,7 +96,9 @@ paths:
                   stringField:
                     type: string
                   stringArrayField:
-                    type: string
+                    type: array
+                    items:
+                      type: string
                   enumField:
                     type: string
                     enum: ["A", "B", "C", "D"]
@@ -135,7 +141,9 @@ paths:
                   stringField:
                     type: string
                   stringArrayField:
-                    type: string
+                    type: array
+                    items:
+                      type: string
                   enumField:
                     type: string
                     enum: ["A", "B", "C", "D"]
@@ -176,7 +184,9 @@ paths:
                 stringField:
                   type: string
                 stringArrayField:
-                  type: string
+                  type: array
+                  items:
+                    type: string
                 enumField:
                   type: string
                   enum: ["A", "B", "C", "D"]

--- a/backend/typescript/swagger.yml
+++ b/backend/typescript/swagger.yml
@@ -1,0 +1,517 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: UW Blueprint Starter Code TypeScript API
+  description: An API for the TypeScript Backend of Starter Code
+
+
+# Authentication 
+components:
+  securitySchemes:
+    bearerAuth:            # arbitrary name for the security scheme
+      type: http
+      scheme: bearer
+      bearerFormat: JWT    # optional, arbitrary value for documentation purposes
+
+
+paths:
+  /entities:
+    get:
+      security:
+        - bearerAuth: []
+      tags:
+        - Entity
+      description: Returns a list of entities
+      responses:
+        '200':
+          description: Successfully returned a list of entities
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                      - intField, stringField, boolField, enumField, stringArrayField
+                  properties:
+                    intField:
+                      type: integer
+                    stringField:
+                      type: string
+                    stringArrayField:
+                      type: string
+                    enumField:
+                      type: string
+                      enum: ["A", "B", "C", "D"]
+                    boolField:
+                      type: boolean
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+
+
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - Entity
+      description: Create a new entity
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - intField, stringField, boolField, enumField, stringArrayField
+              properties:
+                intField:
+                  type: integer
+                stringField:
+                  type: string
+                stringArrayField:
+                  type: string
+                enumField:
+                  type: string
+                  enum: ["A", "B", "C", "D"]
+                boolField:
+                  type: boolean
+      responses:
+        '201':
+          description: Successfully created a new entity
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - intField, stringField, boolField, enumField, stringArrayField
+                properties:
+                  intField:
+                    type: integer
+                  stringField:
+                    type: string
+                  stringArrayField:
+                    type: string
+                  enumField:
+                    type: string
+                    enum: ["A", "B", "C", "D"]
+                  boolField:
+                    type: boolean
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+  
+  
+  /entities/{id}:
+    get:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            # type: integer (postgres)
+            # minimum: 1
+            type: string
+          description: The entity ID
+      tags:
+        - Entity
+      description: Returns an entity based on its ID
+      responses:
+        '200':
+          description: Successfully returns entity based on ID
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - intField, stringField, boolField, enumField, stringArrayField
+                properties:
+                  intField:
+                    type: integer
+                  stringField:
+                    type: string
+                  stringArrayField:
+                    type: string
+                  enumField:
+                    type: string
+                    enum: ["A", "B", "C", "D"]
+                  boolField:
+                    type: boolean
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid ID
+
+
+    put:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            # type: integer (postgres)
+            # minimum: 1
+            type: string
+          description: The entity ID
+      tags:
+        - Entity
+      description: Edit an entity based on its ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - intField, stringField, boolField, enumField, stringArrayField
+              properties:
+                intField:
+                  type: integer
+                stringField:
+                  type: string
+                stringArrayField:
+                  type: string
+                enumField:
+                  type: string
+                  enum: ["A", "B", "C", "D"]
+                boolField:
+                  type: boolean
+      responses:
+        '200':
+          description: Successfully edited entity based on ID
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+
+
+    delete:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            # type: integer (postgres)
+            # minimum: 1
+            type: string
+          description: The entity ID
+      tags:
+        - Entity
+      description: Delete an entity based on its ID
+      responses:
+        '204':
+          description: Successfully deleted entity based on ID
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid ID
+
+    
+  /auth/login:
+    post:
+      tags:
+        - Auth
+      description: Login user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - email, password
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description:  Returns access token in response body and sets refreshToken as an httpOnly cookie
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:   
+                  accessToken:
+                    type: string
+                  id:
+                    type: string
+                  firstName:
+                    type: string
+                  lastName:
+                    type: string
+                  email:
+                    type: string
+                  role:
+                    type: string
+        '500':
+          description: Invalid request
+         
+
+  /auth/refresh:
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - Auth
+      description: Refresh auth credentials
+      responses:
+        '200':
+          description:  Returns access token in response body and sets refreshToken as an httpOnly cookie
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:   
+                  accessToken:
+                    type: string
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+                  
+                
+  /auth/logout/{userid}:
+    post:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: userid
+          required: true
+          schema:
+            # type: integer (postgres)
+            # minimum: 1
+            type: string
+          description: The user ID
+      tags:
+        - Auth
+      description: Logout as user
+      responses:
+        '204':
+          description: Revokes all of the specified user's refresh tokens
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+
+
+  /auth/resetPassword/{email}:
+    post:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: email
+          required: true
+          schema:
+            type: string
+      tags:
+        - Auth
+      description: Triggers password reset for user with specified email (reset link will be emailed)
+      responses:
+        '204':
+          description: Successfully sent password reset email
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+
+
+  /users:
+    get:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            # type: integer (postgres)
+            # minimum: 1
+            type: string
+          description: The user ID
+        - in: query
+          name: email
+          schema:
+            type: string
+          description: The user's email
+      tags:
+        - User
+      description: Get all users, optionally filter by a userId or email query parameter to retrieve a single user
+      responses:
+        '200':
+          description: Successfully returned a list of users, or a user filtered by id or email
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                      - id, firstName, lastName, email, role
+                  properties:
+                    id:
+                      type: string
+                    firstName:
+                      type: string
+                    lastName:
+                      type: string
+                    email:
+                      type: string
+                    role:
+                      type: string
+        '400':
+          description: Cannot query by both user and email
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+
+
+    post:
+      security:
+        - bearerAuth: []
+      tags:
+        - User
+      description: Create new user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - firstName, lastName, role, email
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                role:
+                  type: string
+                  enum: ["User", "Admin"]
+                email:
+                  type: string
+      responses:
+        '201':
+          description: Successfully created a new user
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                    - id, firstName, lastName, email, role
+                properties:
+                  id:
+                    type: string
+                  firstName:
+                    type: string
+                  lastName:
+                    type: string
+                  email:
+                    type: string
+                  role:
+                    type: string
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+
+          
+    delete:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: userId
+          schema:
+            # type: integer (postgres)
+            # minimum: 1
+            type: string
+          description: The user ID
+        - in: query
+          name: email
+          schema:
+            type: string
+          description: The user's email
+      tags:
+        - User
+      description: Deletes a user by userId or email, specified through a query parameter
+      responses:
+        '204':
+          description: Succesfully deleted user
+        '400':
+          description: Cannot query by both userId and email, invalid userId or email, userId or email is not a string, userId or email not supplied
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request
+
+                
+  /users/{userId}:
+    put:
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            # type: integer (postgres)
+            # minimum: 1
+            type: string
+          description: The user ID
+      tags:
+        - User
+      description: Update the user with the specified userId
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - firstName, lastName, role, email
+              properties:
+                firstName:
+                  type: string
+                lastName:
+                  type: string
+                role:
+                  type: string
+                  enum: ["User", "Admin"]
+                email:
+                  type: string
+      responses:
+        '200':
+          description: Successfully updated user
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                    - id, firstName, lastName, email, role
+                properties:
+                  id:
+                    type: string
+                  firstName:
+                    type: string
+                  lastName:
+                    type: string
+                  email:
+                    type: string
+                  role:
+                    type: string
+        '401':
+          description: Unauthorized
+        '500':
+          description: Invalid request

--- a/backend/typescript/yarn.lock
+++ b/backend/typescript/yarn.lock
@@ -693,6 +693,14 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
+"@types/swagger-ui-express@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@types/swagger-ui-express/-/swagger-ui-express-4.1.2.tgz#cfc884904a104c3193f46f423d04ee0416be1ef4"
+  integrity sha512-t9teFTU8dKe69rX9EwL6OM2hbVquYdFM+sQ0REny4RalPlxAm+zyP04B12j4c7qEuDS6CnlwICywqWStPA3v4g==
+  dependencies:
+    "@types/express" "*"
+    "@types/serve-static" "*"
+
 "@types/umzug@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@types/umzug/-/umzug-2.3.0.tgz#74ede18cf837ed8daa257c2bcf5a54e351c2a551"
@@ -717,6 +725,11 @@
   integrity sha512-ISCK1iFnR+jYv7+jLNX0wDqesZ/5RAeY3wUx6QaphmocphU61h+b+PHjS18TF4WIPTu/MMzxIq2PHr32o2TS5Q==
   dependencies:
     "@types/node" "*"
+
+"@types/yamljs@^0.2.31":
+  version "0.2.31"
+  resolved "https://registry.yarnpkg.com/@types/yamljs/-/yamljs-0.2.31.tgz#b1a620b115c96db7b3bfdf0cf54aee0c57139245"
+  integrity sha512-QcJ5ZczaXAqbVD3o8mw/mEBhRvO5UAdTtbvgwL/OgoWubvNBh6/MxLBAigtcgIFaq3shon9m3POIxQaLQt4fxQ==
 
 "@typescript-eslint/eslint-plugin@^4.4.1":
   version "4.15.2"
@@ -2316,7 +2329,7 @@ glob@7.1.6, glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.6:
+glob@^7.0.5, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -4262,6 +4275,18 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+swagger-ui-dist@^3.18.1:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/swagger-ui-dist/-/swagger-ui-dist-3.49.0.tgz#8915df662b74a4dbc9583cd6d3d726c3910e3b33"
+  integrity sha512-R1+eT16XNP1bBLfacISifZAkFJlpwvWsS2vVurF5pbIFZnmCasD/hj+9r/q7urYdQyb0B6v11mDnuYU7rUpfQg==
+
+swagger-ui-express@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz#682294af3d5c70f74a1fa4d6a9b503a9ee55ea82"
+  integrity sha512-Xs2BGGudvDBtL7RXcYtNvHsFtP1DBFPMJFRxHe5ez/VG/rzVOEjazJOOSc/kSCyxreCTKfJrII6MJlL9a6t8vw==
+  dependencies:
+    swagger-ui-dist "^3.18.1"
+
 symbol-observable@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
@@ -4676,6 +4701,14 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yamljs@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/yamljs/-/yamljs-0.3.0.tgz#dc060bf267447b39f7304e9b2bfbe8b5a7ddb03b"
+  integrity sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==
+  dependencies:
+    argparse "^1.0.7"
+    glob "^7.0.5"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Set up Swagger UI for REST APIs](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=48d82954b93c4fb8a9760a379a0fa45d)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Add swagger config file


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Start the server locally with docker-compose up --build (currently it works with mongo + auth, other combos can be tested after scrubbing) * Note that you may need to change entityRoutes file to use EntityServiceMg
2. Navigate to http://localhost:5000/api-docs
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/37782734/120908519-13a5ca80-c639-11eb-90e9-b1c003b1958f.png">

3. Test the login endpoint, then add the accessToken using the Authorize button in the top right
4. Test out the remaining endpoints, similar to Postman


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* Do all the endpoints work? Should the wording be updated for any endpoints


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
