### PR TITLE
Fix generate_csv_from_list arguments in Python entity and user routes

### DIFF
--- a/backend/python/app/rest/entity_routes.py
+++ b/backend/python/app/rest/entity_routes.py
@@ -35,7 +35,7 @@ def get_entities():
     content_type = request.mimetype
 
     if content_type == "text/csv":
-        return jsonify(generate_csv_from_list(result, options=DEFAULT_CSV_OPTIONS)), 200
+        return jsonify(generate_csv_from_list(result, **DEFAULT_CSV_OPTIONS)), 200
 
     return jsonify(result), 200
 

--- a/backend/python/app/rest/user_routes.py
+++ b/backend/python/app/rest/user_routes.py
@@ -52,7 +52,11 @@ def get_users():
 
             if content_type == "text/csv":
                 return (
-                    jsonify(generate_csv_from_list(users, options=DEFAULT_CSV_OPTIONS)),
+                    jsonify(
+                        generate_csv_from_list(
+                            [user.__dict__ for user in users], **DEFAULT_CSV_OPTIONS
+                        )
+                    ),
                     200,
                 )
 

--- a/backend/python/app/utilities/csv_utils.py
+++ b/backend/python/app/utilities/csv_utils.py
@@ -141,7 +141,7 @@ def generate_csv_from_list(dict_list, **kwargs):
         dict_list = [flatten_lists_in_dict(dict) for dict in dict_list]
 
     output = io.StringIO()
-    writer = csv.DictWriter(output, fieldnames=dict_list[0].keys())
+    writer = csv.DictWriter(output, fieldnames=field_names)
 
     if kwargs.get("header", None):
         writer.writeheader()


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
N/A


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Fixed the function calls to `generate_csv_from_list` in `user_routes` and `entity_routes`, which expects a list of dicts and kwargs


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the Python backend
2. Generate an auth token
3. Make a GET request to `/entities` with `Content-Type` being `text/csv`, you should see a response like this:
![image](https://user-images.githubusercontent.com/30205929/131288318-f4ee83f0-a97b-4132-82bc-229813b4ede3.png)
4. Make a GET request to `/users` with `Content-Type` being `text/csv`, you should see a response with headers: `id,first_name,last_name,email,role`



<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
