### PR TITLE
Fix error when deleting an entity with no file in Python

### DIFF
--- a/backend/python/app/services/implementations/entity_service_mg.py
+++ b/backend/python/app/services/implementations/entity_service_mg.py
@@ -79,7 +79,7 @@ class EntityService(IEntityService):
         try:
             file_name = Entity.objects.get(id=id).file_name
             deleted = Entity.objects(id=id).modify(remove=True)
-            if deleted:
+            if deleted and file_name:
                 self.file_storage_service.delete_file(file_name)
             return id
         except Exception as error:

--- a/backend/typescript/rest/entityRoutes.ts
+++ b/backend/typescript/rest/entityRoutes.ts
@@ -116,7 +116,7 @@ entityRouter.delete("/:id", async (req, res) => {
 
   try {
     await entityService.deleteEntity(id);
-    res.status(204).send();
+    res.status(200).send();
   } catch (e) {
     res.status(500).send(e.message);
   }

--- a/backend/typescript/rest/entityRoutes.ts
+++ b/backend/typescript/rest/entityRoutes.ts
@@ -115,8 +115,8 @@ entityRouter.delete("/:id", async (req, res) => {
   const { id } = req.params;
 
   try {
-    await entityService.deleteEntity(id);
-    res.status(200).send();
+    const deletedId = await entityService.deleteEntity(id);
+    res.status(200).json({ id: deletedId });
   } catch (e) {
     res.status(500).send(e.message);
   }

--- a/backend/typescript/services/implementations/EntityServiceMg.ts
+++ b/backend/typescript/services/implementations/EntityServiceMg.ts
@@ -140,7 +140,7 @@ class EntityService implements IEntityService {
     };
   }
 
-  async deleteEntity(id: string): Promise<void> {
+  async deleteEntity(id: string): Promise<string> {
     try {
       const deletedEntity: Entity | null = await MgEntity.findByIdAndDelete(id);
       if (!deletedEntity) {
@@ -149,6 +149,7 @@ class EntityService implements IEntityService {
       if (deletedEntity.fileName) {
         await this.storageService.deleteFile(deletedEntity.fileName);
       }
+      return id;
     } catch (error) {
       Logger.error(`Failed to delete entity. Reason = ${error.message}`);
       throw error;

--- a/backend/typescript/services/implementations/EntityServicePg.ts
+++ b/backend/typescript/services/implementations/EntityServicePg.ts
@@ -156,7 +156,7 @@ class EntityService implements IEntityService {
     };
   }
 
-  async deleteEntity(id: string): Promise<void> {
+  async deleteEntity(id: string): Promise<string> {
     try {
       const entityToDelete = await PgEntity.findByPk(id, { raw: true });
       const deleteResult: number | null = await PgEntity.destroy({
@@ -169,6 +169,7 @@ class EntityService implements IEntityService {
       if (entityToDelete.file_name) {
         await this.storageService.deleteFile(entityToDelete.file_name);
       }
+      return id;
     } catch (error) {
       Logger.error(`Failed to delete entity. Reason = ${error.message}`);
       throw error;

--- a/backend/typescript/services/interfaces/IEntityService.ts
+++ b/backend/typescript/services/interfaces/IEntityService.ts
@@ -58,7 +58,8 @@ export interface IEntityService {
   /**
    * delete the entity with the given id
    * @param id entity id
+   * @returns id of the entity deleted
    * @throws Error if deletion fails
    */
-  deleteEntity(id: string): Promise<void>;
+  deleteEntity(id: string): Promise<string>;
 }

--- a/backend/typescript/swagger.yml
+++ b/backend/typescript/swagger.yml
@@ -272,7 +272,7 @@ paths:
         - Entity
       description: Delete an entity based on its ID
       responses:
-        '204':
+        '200':
           description: Successfully deleted entity based on ID
         '401':
           description: Unauthorized


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* When deleting an entity with no file in Python, there is an error saying `Failed to delete file None. Reason = None could not be converted to unicode`
* Updated response code for delete entity to be consistent with TypeScript implementation



<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Use Python and delete an entity that has no file


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* I remember discussing the response code for delete before but I can't remember why we use 200 instead of 204, was there a reason?


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
