### PR TITLE
Fix content_type check in Python validate middleware

### DIFF
--- a/backend/python/app/middlewares/validate.py
+++ b/backend/python/app/middlewares/validate.py
@@ -26,7 +26,11 @@ def validate_request(dto_class_name):
     def validate_dto(api_func):
         @wraps(api_func)
         def wrapper(*args, **kwargs):
-            if request.content_type == "application/json":
+            if (
+                request.content_type
+                and len(request.content_type.split(";")) > 0
+                and request.content_type.split(";")[0] == "application/json"
+            ):
                 dto = dtos[dto_class_name](**request.json)
             else:
                 req_body = request.form.get("body", default=None)


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
Closes #148 


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
The previous implementation tries to match `content_type` to "application/json" exactly when validating DTOs. However, Axios actually sets "application/json;charset=UTF-8" as the `content_type` when making requests from the frontend, so we now split `content_type` on a semicolon and compare the first substring.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Run the Python backend (comment out `ts-backend` in `docker-compose.yml`)
2. Modify the frontend such that signup uses the REST implementation
3. Sign up a new user (infra@) from the frontend (the data will be sent with `content_type` as "application/json;charset=UTF-8")


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
