### PR TITLE
Ignore tests under build folder in backend/typescript

### DIFF
--- a/backend/typescript/jest.config.ts
+++ b/backend/typescript/jest.config.ts
@@ -147,7 +147,7 @@ export default {
   testMatch: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[tj]s?(x)"],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  testPathIgnorePatterns: ["/node_modules/"],
+  testPathIgnorePatterns: ["/build/", "/node_modules/"],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
   // testRegex: [],


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your ticket's URL -->
Closes #156


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Adds "/build/" to `testPathIgnorePatterns` in jest.config.ts


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Comment out `frontend` and `py-backend` in docker-compose.yml and run the application
```bash
docker-compose up --build
```
2. Run backend tests
```
docker exec -it scv2_ts_backend /bin/bash -c "yarn test"
```

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
