### PR TITLE
Prepend 'Bearer' to access token in BaseAPIClient

### DIFF
--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -55,7 +55,7 @@ baseAPIClient.interceptors.request.use(async (config: AxiosRequestConfig) => {
         accessToken,
       );
 
-      newConfig.headers.Authorization = accessToken;
+      newConfig.headers.Authorization = `Bearer ${accessToken}`;
     }
   }
 


### PR DESCRIPTION
## Ticket link
<!-- Please replace with your ticket's URL -->
N/A, fixing a recently discovered bug that applies to the REST implementation.

**Bug details:**
When the request interceptor in `BaseAPIClient` detects an expired access token in the course of sending a request, it first obtains a new token via a refresh API call and it then replaces the `Authorization` header for the original request with the new token. However, the access token is wrongly replaced without the `Bearer` prefix, which causes the subsequent execution of the original request to fail.

**To reproduce:**
1. Change the `Logout` component to use the REST backend
2. Change `<=` to `>` on this [line](https://github.com/uwblueprint/starter-code-v2/blob/main/frontend/src/APIClients/BaseAPIClient.ts#L43) so that a refresh request is always executed for all REST API calls
3. Login through the frontend, then logout and observe that logout fails


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
Request interceptor in `BaseAPIClient` now replaces `Authorization` header with "Bearer" prefix.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. Change the `Logout` component in the frontend to use the REST backend
2. Change `<=` to `>` on this [line](https://github.com/uwblueprint/starter-code-v2/blob/main/frontend/src/APIClients/BaseAPIClient.ts#L43) so that a refresh request is always executed for all REST API calls
3. Comment out one of the backends in docker-compose.yml and run the application
```bash
docker-compose up --build
```
4. Login through the frontend, then logout successfully


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* N/A


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
