### PR TITLE
Change backend port mapping in compose file to 5001 to avoid Airplay conflict on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cd starter-code-v2
 docker-compose up --build
 ```
 
-The backend runs at http://localhost:5000 and the frontend runs at http://localhost:3000. By default, we use GraphQL (with TypeScript backend), REST (with Python backend), MongoDB, with user auth.
+The backend runs at http://localhost:5001 (5000 conflicts with airplay on Mac) and the frontend runs at http://localhost:3000. By default, we use GraphQL (with TypeScript backend), REST (with Python backend), MongoDB, with user auth.
 
 
 ## Creating a Release

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - ./backend/typescript:/app
       - /app/node_modules
     ports:
-      - 5000:5000
+      - 5001:5000
     dns:
       - 8.8.8.8
     depends_on:
@@ -42,7 +42,7 @@ services:
       context: ./backend/python
       dockerfile: Dockerfile
     ports:
-      - 5000:5000
+      - 5001:5000
     dns:
       - 8.8.8.8
     volumes:


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Change default backend port to not be 5000](https://www.notion.so/uwblueprintexecs/Task-Board-929f5a7288854adebb007cbd77be88a3?p=292750d7877248088c3798123cc36a36&pm=s)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* Change port mapping in docker-compose file from 5000:5000 to 5001:5000
* Avoid changing container port 5000 throughout entire starter code


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test
1. on Mac, check if you can use Airplay while running the app


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
