### PR TITLE
Remove user from stuck state if auth token refresh fails

### DIFF
--- a/backend/python/app/rest/auth_routes.py
+++ b/backend/python/app/rest/auth_routes.py
@@ -31,6 +31,7 @@ cookie_options = {
     "httponly": True,
     "samesite": ("None" if os.getenv("PREVIEW_DEPLOY") else "Strict"),
     "secure": (os.getenv("FLASK_CONFIG") == "production"),
+    "max_age": 60 * 60 * 24 * 7,  # 1 week
 }
 
 

--- a/backend/python/app/rest/auth_routes.py
+++ b/backend/python/app/rest/auth_routes.py
@@ -31,7 +31,7 @@ cookie_options = {
     "httponly": True,
     "samesite": ("None" if os.getenv("PREVIEW_DEPLOY") else "Strict"),
     "secure": (os.getenv("FLASK_CONFIG") == "production"),
-    "max_age": 60 * 60 * 24 * 7,  # 1 week
+    "max_age": 60 * 60 * 24 ,  # 1 day
 }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,24 +34,24 @@ services:
         condition: service_healthy
     env_file:
       - ./.env
-  py-backend:
-    # TODO: rename container for your project
-    container_name: scv2_py_backend
-    restart: always
-    build:
-      context: ./backend/python
-      dockerfile: Dockerfile
-    ports:
-      - 8080:8080
-    dns:
-      - 8.8.8.8
-    volumes:
-      - ./backend/python:/app
-    depends_on:
-      db:
-        condition: service_healthy
-    env_file:
-      - ./.env
+  # py-backend:
+  #   # TODO: rename container for your project
+  #   container_name: scv2_py_backend
+  #   restart: always
+  #   build:
+  #     context: ./backend/python
+  #     dockerfile: Dockerfile
+  #   ports:
+  #     - 8080:8080
+  #   dns:
+  #     - 8.8.8.8
+  #   volumes:
+  #     - ./backend/python:/app
+  #   depends_on:
+  #     db:
+  #       condition: service_healthy
+  #   env_file:
+  #     - ./.env
   db:
     # TODO: rename container for your project
     container_name: scv2_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,24 +34,24 @@ services:
         condition: service_healthy
     env_file:
       - ./.env
-  # py-backend:
-  #   # TODO: rename container for your project
-  #   container_name: scv2_py_backend
-  #   restart: always
-  #   build:
-  #     context: ./backend/python
-  #     dockerfile: Dockerfile
-  #   ports:
-  #     - 8080:8080
-  #   dns:
-  #     - 8.8.8.8
-  #   volumes:
-  #     - ./backend/python:/app
-  #   depends_on:
-  #     db:
-  #       condition: service_healthy
-  #   env_file:
-  #     - ./.env
+  py-backend:
+    # TODO: rename container for your project
+    container_name: scv2_py_backend
+    restart: always
+    build:
+      context: ./backend/python
+      dockerfile: Dockerfile
+    ports:
+      - 8080:8080
+    dns:
+      - 8.8.8.8
+    volumes:
+      - ./backend/python:/app
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ./.env
   db:
     # TODO: rename container for your project
     container_name: scv2_db

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -143,7 +143,6 @@ type LogoutFunction = (
 const logout = async (
   authenticatedUserId: string,
   logoutFunction: LogoutFunction,
-  options?: { raiseError?: boolean}
 ): Promise<boolean> => {
   let success = false;
   try {

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -134,7 +134,7 @@ type LogoutFunction = (
   FetchResult<
     {
       logout: null;
-    },
+    }, 
     Record<string, unknown>,
     Record<string, unknown>
   >
@@ -143,6 +143,7 @@ type LogoutFunction = (
 const logout = async (
   authenticatedUserId: string,
   logoutFunction: LogoutFunction,
+  options?: { raiseError?: boolean}
 ): Promise<boolean> => {
   let success = false;
   try {

--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -42,6 +42,7 @@ baseAPIClient.interceptors.request.use(async (config: AxiosRequestConfig) => {
       (typeof decodedToken === "string" ||
         decodedToken.exp <= Math.round(new Date().getTime() / 1000))
     ) {
+      try {
       const { data } = await axios.post(
         `${process.env.REACT_APP_BACKEND_URL}/auth/refresh`,
         {},
@@ -56,6 +57,10 @@ baseAPIClient.interceptors.request.use(async (config: AxiosRequestConfig) => {
       );
 
       newConfig.headers.Authorization = `Bearer ${accessToken}`;
+      } catch (error) {
+        localStorage.removeItem(AUTHENTICATED_USER_KEY);
+        window.location.href = "/login";
+      }
     }
   }
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -49,6 +49,7 @@ const authLink = setContext(async (_, { headers }) => {
       (typeof decodedToken === "string" ||
         decodedToken.exp <= Math.round(new Date().getTime() / 1000))
     ) {
+      try {
       const { data } = await axios.post(
         `${process.env.REACT_APP_BACKEND_URL}/graphql`,
         { query: REFRESH_MUTATION },
@@ -62,6 +63,10 @@ const authLink = setContext(async (_, { headers }) => {
         accessToken,
       );
       token = accessToken;
+      } catch {
+        localStorage.removeItem(AUTHENTICATED_USER_KEY);
+        location.reload();
+      }
     }
   }
   // return the headers to the context so httpLink can read them

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -65,7 +65,7 @@ const authLink = setContext(async (_, { headers }) => {
       token = accessToken;
       } catch {
         localStorage.removeItem(AUTHENTICATED_USER_KEY);
-        location.reload();
+        window.location.reload();
       }
     }
   }


### PR DESCRIPTION
## Notion ticket link
<!-- Please replace with your ticket's URL -->
[Refresh Token Error](https://www.notion.so/uwblueprintexecs/Refresh-Token-Error-4eb7f1e9d1c6498f9797d7e271afef1e?pvs=4)


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->
## Implementation description
* When a refresh fails, forcibly remove the user's invalid auth token from the local storage. Triggering a new token to be created.


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->
## Steps to test

Testing that a missing refresh token is handled:

Log in to your local environment.
Set your system time to a time at least a week in the future.
Close your browser fully and reopen it.
Load any page that pulls data from the backend, and verify that you are logged out.

hehe thanks Connor ^

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->
## What should reviewers focus on?
* 


## Checklist
- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
